### PR TITLE
Update tooltip z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@
 			max-height: calc(100vh - var(--bottom) * 1px - 10px);
 		}
 	}
-	z-index: 10000;
+	z-index: 40000;
 	pointer-events: none;
 
 	> sttt-sep {


### PR DESCRIPTION
29999 and 30000 are used by burger and wand popups respectively, so the tooltip draws below them